### PR TITLE
ruby2.2以前のVersionに対応

### DIFF
--- a/lib/repp/handler/slack.rb
+++ b/lib/repp/handler/slack.rb
@@ -19,7 +19,7 @@ module Repp
             )
             res = app.call(receive)
             if res.first
-              channel_to_post = res.last&.[](:channel) || receive.channel
+              channel_to_post = res.last.nil? ? receive.channel : res.last[:channel]
               web_client.chat_postMessage(text: res.first, channel: channel_to_post, as_user: true)
             end
           end


### PR DESCRIPTION
ruby2.2以前ではSafe Navigation Operatorが利用できないため、利用しない形に変更