### PR TITLE
Add attachments option to slack handler

### DIFF
--- a/lib/repp/handler/slack.rb
+++ b/lib/repp/handler/slack.rb
@@ -46,8 +46,9 @@ module Repp
 
             res = app.call(receive)
             if res.first
-              channel_to_post = res.last.nil? ? receive.channel : res.last[:channel]
-              web_client.chat_postMessage(text: res.first, channel: channel_to_post, as_user: true)
+              channel_to_post = res.last && res.last[:channel] || receive.channel
+              attachments = res.last && res.last[:attachments]
+              web_client.chat_postMessage(text: res.first, channel: channel_to_post, as_user: true, attachments: attachments)
             end
           end
 
@@ -70,7 +71,8 @@ module Repp
             if res.first
               if res.last && res.last[:dest_channel]
                 channel_to_post = res.last[:dest_channel]
-                @web_client.chat_postMessage(text: res.first, channel: channel_to_post, as_user: true)
+                attachments = res.last[:attachments]
+                @web_client.chat_postMessage(text: res.first, channel: channel_to_post, as_user: true, attachments: attachments)
               else
                 message = "Need 'dest_to:' option to every or cron job like:\n" +
                   "every 1.hour, dest_to: 'channel_name' do"


### PR DESCRIPTION

https://api.slack.com/docs/message-attachments

```ruby
# sample with mobb
require 'mobb'
set :service, 'slack'

on 'ping' do
  [
    'pong',
    {
      attachments: [
        { color: '#ff0000', 'title': 'Example', text: 'example attachments' }
      ]
    }
  ]
end
```

<img width="231" alt="2018-09-20 1 38 44" src="https://user-images.githubusercontent.com/1131422/45767732-f4db2c00-bc75-11e8-812c-eae1ed828526.png">
